### PR TITLE
feat: allow cat color customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@
   };
 
   const colorPicker = EL('colorPicker');
+  const themeMeta   = document.querySelector('meta[name="theme-color"]');
 
   function shadeColor(color, percent){
     let f = parseInt(color.slice(1),16), t = percent < 0 ? 0 : 255, p = Math.abs(percent);
@@ -263,6 +264,8 @@
     document.documentElement.style.setProperty('--cat1', shadeColor(hex, 0.15));
     document.documentElement.style.setProperty('--cat2', shadeColor(hex,-0.15));
     document.documentElement.style.setProperty('--catInner', shadeColor(hex, 0.05));
+    document.documentElement.style.setProperty('--accent', hex);
+    if(themeMeta) themeMeta.setAttribute('content', shadeColor(hex, 0.15));
   }
 
   colorPicker.value = state.color;


### PR DESCRIPTION
## Summary
- let users pick a fur color from the UI and persist it
- update theme accent and meta color to match the chosen cat color

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f1508574832e956536b3e227f3ed