### PR TITLE
Ensure PWA updates with refreshed service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,6 +677,12 @@
   ensureAudio();
   if('serviceWorker' in navigator){
     navigator.serviceWorker.register('sw.js');
+    let refreshing;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (refreshing) return;
+      refreshing = true;
+      window.location.reload();
+    });
   }
 })();
 </script>

--- a/sw.js
+++ b/sw.js
@@ -10,6 +10,16 @@ self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE).then(cache => cache.addAll(ASSETS))
   );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Summary
- Update service worker to skip waiting, claim clients, and clean old caches
- Reload page when service worker controller changes to surface new updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898fcdf87e8832eac9d09302167ed85