### PR TITLE
Adjust ears and play logic

### DIFF
--- a/cat-icon.svg
+++ b/cat-icon.svg
@@ -6,8 +6,8 @@
     </linearGradient>
   </defs>
   <circle cx="50" cy="60" r="40" fill="url(#g1)"/>
-  <polygon points="20,60 40,20 50,60" fill="url(#g1)"/>
-  <polygon points="80,60 60,20 50,60" fill="url(#g1)"/>
+  <polygon points="20,50 40,10 50,50" fill="url(#g1)"/>
+  <polygon points="80,50 60,10 50,50" fill="url(#g1)"/>
   <circle cx="35" cy="60" r="6" fill="#071223"/>
   <circle cx="65" cy="60" r="6" fill="#071223"/>
   <polygon points="50,70 45,75 55,75" fill="#071223"/>

--- a/index.html
+++ b/index.html
@@ -206,10 +206,10 @@
             </linearGradient>
           </defs>
           <ellipse cx="100" cy="95" rx="80" ry="70" fill="url(#g1)"/>
-          <polygon points="36,80 80,0 100,80" fill="url(#g1)"/>
-          <polygon points="164,80 120,0 100,80" fill="url(#g1)"/>
-          <polygon points="48,78 80,15 100,78" fill="var(--catInner)"/>
-          <polygon points="152,78 120,15 100,78" fill="var(--catInner)"/>
+          <polygon points="36,60 80,0 100,60" fill="url(#g1)"/>
+          <polygon points="164,60 120,0 100,60" fill="url(#g1)"/>
+          <polygon points="48,60 80,10 100,60" fill="var(--catInner)"/>
+          <polygon points="152,60 120,10 100,60" fill="var(--catInner)"/>
         <ellipse cx="78" cy="70" rx="16" ry="10" fill="rgba(255,255,255,.45)"/>
         <circle id="eyeL" cx="70" cy="90" r="10" fill="#071223"/>
         <circle id="eyeR" cx="130" cy="90" r="10" fill="#071223"/>
@@ -441,6 +441,12 @@
   let loop = setInterval(tick, TICK_MS);
   catchUp();
   resetSleepTimer();
+  document.addEventListener('visibilitychange', () => {
+    if(!document.hidden){
+      catchUp();
+      resetSleepTimer();
+    }
+  });
 
   /* ---------- WebAudio (tiny synth) ---------- */
   let audioCtx = null;
@@ -522,6 +528,7 @@
         break;
       case 'play':
         if(state.sleeping){ speak("Zzz... maybe later."); wobble(); break; }
+        if(state.energy < 10){ speak("I’m too tired to play."); wobble(); break; }
         bump('fun', +24, 'bar-fun'); bump('energy', -10);
         spawnConfetti(); speak("Weeee! That was fun!");
         happyBounce();
@@ -605,8 +612,8 @@
     if(Math.random()<0.05 && !state.sleeping) blink();
     if(Math.random()<0.02 && !state.sleeping) wobble();
 
-    // Only disable play during sleep
-    EL('btnPlay').disabled = state.sleeping;
+    // Disable play when sleeping or low on energy
+    EL('btnPlay').disabled = state.sleeping || state.energy < 10;
 
     const mins = Math.floor(state.ageMinutes);
     const d = Math.floor(mins/ (60*24));


### PR DESCRIPTION
## Summary
- Raise cat ears higher on the head for both main pet and icon
- Disable and reject play action when energy is too low
- Refresh indicators when returning from standby via visibility change listener

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ac59ac038832e92fd25072e2063b5